### PR TITLE
support  asus ac86u fireware version 3.0.0.4.384.81858

### DIFF
--- a/asuswrt/client.py
+++ b/asuswrt/client.py
@@ -121,6 +121,8 @@ class AsusWRT:
 
         clients = response.get('get_clientlist', {})
         clients.pop('maclist', None)
+        clients.pop('ClientAPILevel', None)      # support  asus ac86u fireware version 3.0.0.4.384.81858
+
         clients = list(map(Client, list(clients.values())))
 
         update_interface('2g', '2GHz')


### PR DESCRIPTION
asus ac86u fireware  version 3.0.0.4.384.81858

get_clientlist return One more parameter ClientAPILevel
```
ClientAPILevel:2
```
error info
```
Traceback (most recent call last):
  File "clients.py", line 7, in <module>
    clients = router.get_online_clients()
  File "..\asuswrt\client.py", line 124, in get_online_clients
    clients = list(map(Client, list(clients.values())))
  File "..\asuswrt\model.py", line 9, in __init__
    self.mac = data.get('mac')
AttributeError: 'str' object has no attribute 'get'
```